### PR TITLE
Adds fix to unnecessary rerenders

### DIFF
--- a/src/containers/AppRouter.js
+++ b/src/containers/AppRouter.js
@@ -1,10 +1,5 @@
 import React, { useEffect, useState } from "react";
-import {
-  BrowserRouter as Router,
-  Switch,
-  Route,
-
-} from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 
 import {
   Home,
@@ -12,83 +7,66 @@ import {
   // BadgesHome,
   CreateNewBadges,
   BadgesList,
-  
 } from "./";
 
-import {
-  Notification,
-  AppHeader,
+import { Notification, AppHeader } from "../components";
 
-} from "../components";
-
-import {
-  networkId, 
-  
-} from "../utils/auth"
+import { networkId } from "../utils/auth";
 
 export default function AppRouter() {
   const [notification, showNotification] = useState(false);
   const [notificationMessage, setNotificationMessage] = useState("");
-  
+
   const componentDidMount = () => {
-    if(window.walletConnection.isSignedIn()) {
+    if (window.walletConnection.isSignedIn()) {
       showNotification(true);
       setNotificationMessage("You are logged ");
-      
+
       setTimeout(() => {
         showNotification(false);
-      }, 1000)
+      }, 1000);
     }
-  }
+  };
 
   useEffect(componentDidMount, []);
 
   const isSignedIn = window.walletConnection.isSignedIn();
 
   const RenderNotification = () => {
-    return notification && <Notification message={notificationMessage} networkId={networkId} />
-  }
+    return (
+      notification && (
+        <Notification message={notificationMessage} networkId={networkId} />
+      )
+    );
+  };
 
   const RenderAppHeader = () => {
-    return window.walletConnection.isSignedIn() && (<AppHeader />) 
-  }
+    return window.walletConnection.isSignedIn() && <AppHeader />;
+  };
 
-  const RenderRouter = () => {
-    return (
-      <Router> 
-        { window.walletConnection.isSignedIn() && (<AppHeader />)  }
-        <Switch>
-          <Route path={"/"} exact>
+  return (
+    <>
+      {isSignedIn ? (
+        <Router>
+          {window.walletConnection.isSignedIn() && <AppHeader />}
+          <Switch>
+            <Route path={"/"} exact>
               <Home />
               <RenderNotification />
-          </Route>
-          
-          <Route path={"/new"}>
-           <CreateNewBadges />
-          </Route>
-          
-          <Route path={"/badges/:account"}>
-           <BadgesList />
-          </Route>
-        </Switch>
-      </Router>
-    )
-  }
+            </Route>
 
-  const RenderAppRouter = () => {
-    return (
-      <>
-        {
-          isSignedIn ? (
-            <RenderRouter />
-          ) :  
-          (
-            <Landing />
-          )
-        }
-      </>
-    )
-  }
+            <Route path={"/new"}>
+              <CreateNewBadges />
+            </Route>
 
-  return <RenderAppRouter />
+            <Route path={"/badges/:account"}>
+              <BadgesList />
+            </Route>
+          </Switch>
+        </Router>
+      ) : (
+        <Landing />
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
Closes #12

What I understand was happening is that over `AppRouter` there was about 3 checks that the route would do before it rendered the view, problem was that that each of those check if the user was authenticated would render the view after each

I removed `const RenderAppRouter `, converted the routes into the default return of the function and added the conditional logic beforehand